### PR TITLE
Cannot read property 'indexOf' of null fix.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,9 +1,8 @@
+/* global atom */
+// import fs from 'fs'
 'use strict';
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-/* global atom */
-// import fs from 'fs'
 
 var _path = require('path');
 
@@ -18,7 +17,7 @@ var _child_process = require('child_process');
 
 var linterPackage = atom.packages.getLoadedPackage('linter');
 if (!linterPackage) {
-  atom.notifications.addError('Linter should be installed first, `apm install linter`', { dismissable: true });
+  atom.notifications.addError('Linter should be installed first, `apm install linter`', { dismissable: true }); // eslint-disable-line
 }
 
 // const linterPath = linterPackage.path
@@ -45,8 +44,8 @@ function flowMessageToLinterMessage(arr) {
   var message = Array.isArray(arr) ? arr[0] : arr;
 
   var obj = { type: message.level,
-    text: Array.isArray(arr) ? arr.map(function (obj) {
-      return obj.descr;
+    text: Array.isArray(arr) ? arr.map(function (o) {
+      return o.descr;
     }).join(' ') : message.descr,
     filePath: message.path,
     range: extractRange(message)
@@ -83,12 +82,12 @@ module.exports = { config: { pathToFlowExecutable: { type: 'string',
         var filePath = TextEditor.getPath();
         var fileText = TextEditor.buffer && TextEditor.buffer.cachedText;
 
-        if (fileText.indexOf('@flow') === -1) {
+        if (!fileText || fileText.indexOf('@flow') === -1) {
           return [];
         }
 
         return new Promise(function (resolve, reject) {
-          var command = _child_process.spawn(cmdString, ['check-contents', filePath, '--json', '--timeout', '1'], { cwd: _path2['default'].dirname(filePath) });
+          var command = (0, _child_process.spawn)(cmdString, ['check-contents', filePath, '--json', '--timeout', '1'], { cwd: _path2['default'].dirname(filePath) });
           var data = '',
               errors = '';
           command.stdout.on('data', function (d) {
@@ -107,11 +106,11 @@ module.exports = { config: { pathToFlowExecutable: { type: 'string',
               if (!data.errors || data.passed) {
                 resolve([]);
               } else {
-                var _errors = data.errors.map(function (obj) {
+                var errs = data.errors.map(function (obj) {
                   return obj.message;
                 }).map(flowMessageToLinterMessage);
-                console.log(_errors);
-                resolve(_errors);
+                console.log(errs);
+                resolve(errs);
               }
             }
           });
@@ -121,7 +120,7 @@ module.exports = { config: { pathToFlowExecutable: { type: 'string',
         })['catch'](function (err) {
           console.error(err);
           return [{ type: 'warning',
-            html: 'Error Linting',
+            html: 'linter-flow-plus : Error Linting, check the console for details',
             filePath: filePath,
             range: [[0, 0], [0, 1]]
           }];
@@ -132,4 +131,3 @@ module.exports = { config: { pathToFlowExecutable: { type: 'string',
     return provider;
   }
 };
-// eslint-disable-line

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ module.exports =
             const filePath = TextEditor.getPath()
             const fileText = TextEditor.buffer && TextEditor.buffer.cachedText
 
-            if(fileText.indexOf('@flow') === -1){
+            if(!fileText || fileText.indexOf('@flow') === -1){
               return []
             }
 


### PR DESCRIPTION
First of all, I really like your atom package and thank you for creating it!

**Issue**
I get this error from time to time while I'm using your package. 
The error occurs somewhat random, your package keeps working and I only get the error message.

```
TypeError: Cannot read property 'indexOf' of null
    at Object.lint (/Users/dannyvanderjagt/.atom/packages/linter-flow-plus/build/index.js:86:21)
    at Promise.then._this.emitter.emit.linter (/Users/dannyvanderjagt/.atom/packages/linter/lib/linter-registry.coffee:95:31)
    at LinterRegistry.triggerLinter (/Users/dannyvanderjagt/.atom/packages/linter/lib/linter-registry.coffee:94:14)
    at /Users/dannyvanderjagt/.atom/packages/linter/lib/linter-registry.coffee:82:26
    at Array.map (native)
    at /Users/dannyvanderjagt/.atom/packages/linter/lib/linter-registry.coffee:78:36
    at process._tickCallback (node.js:367:9)
```

**Solution**
I fixed this error by checking if `fileText` is `null` before using  `indexOf`. I assumed that if the fileText is equal to null that it also should `return []`. 
I also did the rebuild.

@nmn What are your thoughts on this?
